### PR TITLE
Fix #31

### DIFF
--- a/DataFormat.md
+++ b/DataFormat.md
@@ -245,16 +245,15 @@ The event name is defined in the class `selogger.EventType`.
 |Object manipulation (OBJECT)|OBJECT_CONSTANT_LOAD|When a constant object (usually String) is loaded by the instruction.|Object loaded by the instruction.  This may be null.|
 |                            |OBJECT_INSTANCEOF|Before the INSTANCEOF instruction is executed.|Object whose class is checked by the instruction|
 |                            |OBJECT_INSTANCEOF_RESULT|After the INSTANCEOF instruction is executed.|Result (true or false) of the instruction|
-|Local variables (LOCAL)|LOCAL_LOAD|Before the value of the local variable is read by a local variable instruction (one of ALOD, DLOAD, FLOAD, ILOAD, and LLOAD)|Value read from the variable|
-|                       |LOCAL_STORE|Before the value is written to the local variable by an instruction (one of ASTORE, DSTORE, FSTORE, ISTORE, and LSTORE) |Value written to the variable|
-|                       |LOCAL_INCREMENT|After the local variable is updated by an IINC instruction.  An IINC instruction is not only for `i++`; it is also used for `i+=k` and `i-=k` if `k` is constant (depending on a compiler).|Value written to the variable by an increment instruction|
-|                       |RET|This event corresponds to a RET instruction for subroutine call.  The current version does not generate this event.||
-|Control-flow events (LABEL)|LABEL|This event is recorded when an execution passed a particular code location. LABEL itself is not a Java bytecode, a pseudo instruction inserted by ASM bytecode manipulation library used by SELogger.|A dataId corresponding to the previous program location is recorded so that a user can trace a control-flow path.|
-|                           |CATCH_LABEL|This event is recorded when an execution entered a catch/finally block.|A dataId corresponding to the previous program location (that is likely where an exception was thrown) is recorded.|
-|                           |CATCH|When an execution entered a catch/finally block, immediately after a CATCH_LABEL event, before any instructions in the catch/finally block is executed.|Exception object caught by the block|
-|                           |JUMP|This event represents a jump instruction in bytecode. |The event itself is not directly recorded in a trace.  The dataId of this event may appear in LABEL events.|
-|                           |DIVIDE|This event represents an arithmetic division instruction (IDIV).|The event itself is not directly recorded in a trace.  The dataId of this event may appear in LABEL events.|
-|                           |LINE_NUMBER|This event represents an execution of a line of source code.  As a single line of code may be compiled into separated bytecode blocks, a number of LINE_NUMBER events having different data ID may point to the same line number.||
+|Local variables (LOCAL)     |LOCAL_LOAD|Before the value of the local variable is read by a local variable instruction (one of ALOD, DLOAD, FLOAD, ILOAD, and LLOAD)|Value read from the variable|
+|                            |LOCAL_STORE|Before the value is written to the local variable by an instruction (one of ASTORE, DSTORE, FSTORE, ISTORE, and LSTORE) |Value written to the variable|
+|                            |LOCAL_INCREMENT|After the local variable is updated by an IINC instruction.  An IINC instruction is not only for `i++`; it is also used for `i+=k` and `i-=k` if `k` is constant (depending on a compiler).|Value written to the variable by an increment instruction|
+|                            |RET|This event corresponds to a RET instruction for subroutine call.  The current version does not generate this event.||
+|Control-flow events (LABEL) |LABEL|This event is recorded when an execution passed a particular code location. LABEL itself is not a Java bytecode, a pseudo instruction inserted by ASM bytecode manipulation library used by SELogger.|A bytecode instruction index of the previous program location is recorded so that a user can trace a control-flow path.|
+|                            |CATCH_LABEL|This event is recorded when an execution entered a catch/finally block.|A bytecode instruction index of the previous program location (that is likely where an exception was thrown) is recorded.|
+|                            |JUMP|This event represents a jump instruction in bytecode.  |While this event appears in a list of IDs to show the instruction index, the event itself is not directly recorded in a trace.|
+|Line number events (LINE)   |LINE_NUMBER|This event represents an execution of a line of source code.  As a single line of code may be compiled into separated bytecode blocks, a number of LINE_NUMBER events having different data ID may point to the same line number.||
+|Other events                |CATCH|This event is recorded when an execution entered a catch/finally block.  This event is observed if any of CALL, FIELD, ARRAY, and SYNC events are observed.|Exception object caught by the block|
 
 
 

--- a/src/selogger/weaver/WeaveConfig.java
+++ b/src/selogger/weaver/WeaveConfig.java
@@ -186,7 +186,6 @@ public class WeaveConfig {
 		return recordMethodCall() || 
 				recordFieldAccess() || 
 				recordArrayInstructions() ||
-				recordLabel() ||
 				recordSynchronization();
 	}
 	

--- a/tests/selogger/logging/io/LatestEventLoggerTest.java
+++ b/tests/selogger/logging/io/LatestEventLoggerTest.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import selogger.EventType;
 import selogger.logging.io.LatestEventLogger.ObjectRecordingStrategy;
 import selogger.logging.util.ObjectId;
+import selogger.logging.util.ThreadId;
 import selogger.weaver.DataInfo;
 import selogger.weaver.MethodInfo;
 import selogger.weaver.method.Descriptor;
@@ -213,5 +214,27 @@ public class LatestEventLoggerTest {
 		Assert.assertEquals("test", exceptionId.getContent());
 		Assert.assertEquals("java.lang.Throwable", exceptionId.getClassName());
 	}
-	
+
+	@Test
+	public void testPrimitiveTypes() {
+		LatestEventLogger logger = new LatestEventLogger(null, 1, ObjectRecordingStrategy.Weak, true, null);
+		logger.recordEvent(0, (char)1);
+		logger.recordEvent(1, (short)2);
+		logger.recordEvent(2, Float.NaN);
+		logger.recordEvent(3, (byte)4);
+		logger.recordEvent(4, 5D);
+		logger.recordEvent(5, true);
+		
+		LatestEventBuffer buf = logger.prepareBuffer(int.class, 1);
+		long seq = buf.getSeqNum(0);
+		Assert.assertEquals("1,1,2," + seq + "," + ThreadId.get(), buf.toString());
+
+		buf = logger.prepareBuffer(byte.class, 3);
+		seq = buf.getSeqNum(0);
+		Assert.assertEquals("1,1,4," + seq + "," + ThreadId.get(), buf.toString());
+
+		buf = logger.prepareBuffer(float.class, 2);
+		seq = buf.getSeqNum(0);
+		Assert.assertEquals("1,1,NaN," + seq + "," + ThreadId.get(), buf.toString());
+	}
 }

--- a/tests/selogger/testdata/SimpleTarget.java
+++ b/tests/selogger/testdata/SimpleTarget.java
@@ -188,5 +188,13 @@ public class SimpleTarget {
 			return false;
 		}
 	}
+	
+	public int divide(int x) {
+		try {
+			return 1 / x;
+		} catch (ArithmeticException e) {
+			return 0;
+		}
+	}
 
 }

--- a/tests/selogger/testdata/SimpleTarget.java
+++ b/tests/selogger/testdata/SimpleTarget.java
@@ -180,5 +180,13 @@ public class SimpleTarget {
 		useLocal();
 		
 	}
+	
+	public boolean nestedConditions(int x, int y) {
+		if ((x > 0 && y > 0) && (x==y)) {
+			return true;
+		} else {
+			return false;
+		}
+	}
 
 }

--- a/tests/selogger/weaver/ClassInfoTest.java
+++ b/tests/selogger/weaver/ClassInfoTest.java
@@ -1,0 +1,30 @@
+package selogger.weaver;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ClassInfoTest {
+
+	@Test
+	public void testClassInfo() {
+		ClassInfo c = new ClassInfo(1, "container", "filename", "classname", LogLevel.Normal, "0101", "#id");
+		String s = c.toString();
+		ClassInfo c2 = ClassInfo.parse(s);
+		
+		Assert.assertEquals(1, c.getClassId());
+		Assert.assertEquals("#id", c.getClassLoaderIdentifier());
+		Assert.assertEquals("classname", c.getClassName());
+		Assert.assertEquals("filename", c.getFilename());
+		Assert.assertEquals("container", c.getContainer());
+		Assert.assertEquals(LogLevel.Normal, c.getLoglevel());
+		Assert.assertEquals("0101", c.getHash());
+
+		Assert.assertEquals(1, c2.getClassId());
+		Assert.assertEquals("#id", c2.getClassLoaderIdentifier());
+		Assert.assertEquals("classname", c2.getClassName());
+		Assert.assertEquals("filename", c2.getFilename());
+		Assert.assertEquals("container", c2.getContainer());
+		Assert.assertEquals(LogLevel.Normal, c2.getLoglevel());
+		Assert.assertEquals("0101", c2.getHash());
+	}
+}

--- a/tests/selogger/weaver/EventIterator.java
+++ b/tests/selogger/weaver/EventIterator.java
@@ -1,5 +1,7 @@
 package selogger.weaver;
 
+import java.util.Collection;
+
 import selogger.EventType;
 import selogger.logging.io.MemoryLogger;
 import selogger.weaver.method.Descriptor;
@@ -34,6 +36,21 @@ public class EventIterator {
 	public boolean next() {
 		eventIndex++;
 		return eventIndex < memoryLogger.getEvents().size();
+	}
+	
+	/**
+	 * Proceed to the next event of interest
+	 * @param eventsOfInterest specifies event types of interest.
+	 * @return true if the event data is available.
+	 * False indicate the end of data.
+	 */
+	public boolean nextSpecifiedEvent(Collection<EventType> eventsOfInterest) {
+		while (next()) {
+			if (eventsOfInterest.contains(getEventType())) {
+				return true;
+			}
+		} 
+		return false;
 	}
 	
 	/**

--- a/tests/selogger/weaver/EventIterator.java
+++ b/tests/selogger/weaver/EventIterator.java
@@ -70,6 +70,22 @@ public class EventIterator {
 	}
 	
 	/**
+	 * @return the line number of the data ID of the current event 
+	 */
+	public int getLine() {
+		int dataId = memoryLogger.getEvents().get(eventIndex).getDataId();
+		return weaveLog.getDataEntries().get(dataId).getLine();
+	}
+	
+	/**
+	 * @return the instruction index of the data ID of the current event 
+	 */
+	public int getInstructionIndex() {
+		int dataId = memoryLogger.getEvents().get(eventIndex).getDataId();
+		return weaveLog.getDataEntries().get(dataId).getInstructionIndex();
+	}
+	
+	/**
 	 * @return the observed value of the event  
 	 */
 	public float getFloatValue() {

--- a/tests/selogger/weaver/MethodInfoTest.java
+++ b/tests/selogger/weaver/MethodInfoTest.java
@@ -1,0 +1,34 @@
+package selogger.weaver;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MethodInfoTest {
+
+	@Test
+	public void testMethodInfo() {
+		MethodInfo m = new MethodInfo(123, 456, "classname", "methodname", "desc", 7, "source", "0123456789ABCDEF");
+		String s = m.toString();
+		MethodInfo m2 = MethodInfo.parse(s);
+		
+		Assert.assertEquals(123, m.getClassId());
+		Assert.assertEquals(456, m.getMethodId());
+		Assert.assertEquals("classname", m.getClassName());
+		Assert.assertEquals("methodname", m.getMethodName());
+		Assert.assertEquals("desc", m.getMethodDesc());
+		Assert.assertEquals(7, m.getAccess());
+		Assert.assertEquals("source", m.getSourceFileName());
+		Assert.assertEquals("0123456789ABCDEF", m.getMethodHash());
+		Assert.assertEquals("01234567", m.getShortMethodHash());
+		
+		Assert.assertEquals(123, m2.getClassId());
+		Assert.assertEquals(456, m2.getMethodId());
+		Assert.assertEquals("classname", m2.getClassName());
+		Assert.assertEquals("methodname", m2.getMethodName());
+		Assert.assertEquals("desc", m2.getMethodDesc());
+		Assert.assertEquals(7, m2.getAccess());
+		Assert.assertEquals("source", m2.getSourceFileName());
+		Assert.assertEquals("0123456789ABCDEF", m2.getMethodHash());
+		Assert.assertEquals("01234567", m2.getShortMethodHash());
+	}
+}

--- a/tests/selogger/weaver/WeaverAllTest.java
+++ b/tests/selogger/weaver/WeaverAllTest.java
@@ -143,15 +143,15 @@ public class WeaverAllTest {
 		execEvents = new HashSet<>(Arrays.asList(new EventType[] {EventType.METHOD_ENTRY, EventType.METHOD_NORMAL_EXIT, EventType.METHOD_EXCEPTIONAL_EXIT, EventType.METHOD_THROW, EventType.METHOD_OBJECT_INITIALIZED}));
 		execParamEvents = new HashSet<>(execEvents);
 		execParamEvents.addAll(Arrays.asList(new EventType[] {EventType.METHOD_PARAM}));
-		callEvents = new HashSet<>(Arrays.asList(new EventType[] {EventType.CALL, EventType.CALL_RETURN, EventType.CATCH, EventType.CATCH_LABEL, EventType.INVOKE_DYNAMIC, EventType.INVOKE_DYNAMIC_RESULT}));
+		callEvents = new HashSet<>(Arrays.asList(new EventType[] {EventType.CALL, EventType.CALL_RETURN, EventType.CATCH, EventType.INVOKE_DYNAMIC, EventType.INVOKE_DYNAMIC_RESULT}));
 		callParamEvents = new HashSet<>(callEvents);
 		callParamEvents.addAll(Arrays.asList(new EventType[] {EventType.NEW_OBJECT, EventType.NEW_OBJECT_CREATED, EventType.CALL_PARAM, EventType.INVOKE_DYNAMIC_PARAM}));
 		localEvents = new HashSet<>(Arrays.asList(new EventType[] {EventType.LOCAL_LOAD, EventType.LOCAL_STORE, EventType.LOCAL_INCREMENT}));
-		fieldEvents = new HashSet<>(Arrays.asList(new EventType[] {EventType.GET_INSTANCE_FIELD, EventType.GET_INSTANCE_FIELD_RESULT, EventType.GET_STATIC_FIELD, EventType.PUT_INSTANCE_FIELD, EventType.PUT_INSTANCE_FIELD_BEFORE_INITIALIZATION, EventType.PUT_INSTANCE_FIELD_VALUE, EventType.PUT_STATIC_FIELD, EventType.CATCH, EventType.CATCH_LABEL}));
-		arrayEvents = new HashSet<>(Arrays.asList(new EventType[] {EventType.ARRAY_LENGTH, EventType.ARRAY_LENGTH_RESULT, EventType.ARRAY_LOAD, EventType.ARRAY_LOAD_INDEX, EventType.ARRAY_LOAD_RESULT, EventType.ARRAY_STORE, EventType.ARRAY_STORE_INDEX, EventType.ARRAY_STORE_VALUE, EventType.MULTI_NEW_ARRAY, EventType.MULTI_NEW_ARRAY_ELEMENT, EventType.MULTI_NEW_ARRAY_OWNER, EventType.NEW_ARRAY, EventType.NEW_ARRAY_RESULT, EventType.CATCH, EventType.CATCH_LABEL}));
-		syncEvents = new HashSet<>(Arrays.asList(new EventType[] {EventType.MONITOR_ENTER, EventType.MONITOR_ENTER_RESULT, EventType.MONITOR_EXIT, EventType.CATCH, EventType.CATCH_LABEL}));
+		fieldEvents = new HashSet<>(Arrays.asList(new EventType[] {EventType.GET_INSTANCE_FIELD, EventType.GET_INSTANCE_FIELD_RESULT, EventType.GET_STATIC_FIELD, EventType.PUT_INSTANCE_FIELD, EventType.PUT_INSTANCE_FIELD_BEFORE_INITIALIZATION, EventType.PUT_INSTANCE_FIELD_VALUE, EventType.PUT_STATIC_FIELD, EventType.CATCH}));
+		arrayEvents = new HashSet<>(Arrays.asList(new EventType[] {EventType.ARRAY_LENGTH, EventType.ARRAY_LENGTH_RESULT, EventType.ARRAY_LOAD, EventType.ARRAY_LOAD_INDEX, EventType.ARRAY_LOAD_RESULT, EventType.ARRAY_STORE, EventType.ARRAY_STORE_INDEX, EventType.ARRAY_STORE_VALUE, EventType.MULTI_NEW_ARRAY, EventType.MULTI_NEW_ARRAY_ELEMENT, EventType.MULTI_NEW_ARRAY_OWNER, EventType.NEW_ARRAY, EventType.NEW_ARRAY_RESULT, EventType.CATCH}));
+		syncEvents = new HashSet<>(Arrays.asList(new EventType[] {EventType.MONITOR_ENTER, EventType.MONITOR_ENTER_RESULT, EventType.MONITOR_EXIT, EventType.CATCH}));
 		objectEvents = new HashSet<>(Arrays.asList(new EventType[] {EventType.OBJECT_CONSTANT_LOAD, EventType.OBJECT_INSTANCEOF, EventType.OBJECT_INSTANCEOF_RESULT}));
-		labelEvents = new HashSet<>(Arrays.asList(new EventType[] {EventType.LABEL, EventType.CATCH, EventType.CATCH_LABEL}));
+		labelEvents = new HashSet<>(Arrays.asList(new EventType[] {EventType.LABEL, EventType.CATCH_LABEL}));
 		lineEvents = new HashSet<>(Arrays.asList(new EventType[] {EventType.LINE_NUMBER}));
 	}
 
@@ -185,6 +185,7 @@ public class WeaverAllTest {
 				t != EventType.RET && 
 				t != EventType.JUMP && 
 				t != EventType.LABEL &&
+				t != EventType.CATCH_LABEL &&
 				t != EventType.LINE_NUMBER &&
 				!localEvents.contains(t)) {
 				events.add(t);
@@ -204,6 +205,7 @@ public class WeaverAllTest {
 				t != EventType.RET && 
 				t != EventType.JUMP && 
 				t != EventType.LABEL &&
+				t != EventType.CATCH_LABEL &&
 				t != EventType.LINE_NUMBER) {
 				events.add(t);
 			}

--- a/tests/selogger/weaver/WeaverLabelTest.java
+++ b/tests/selogger/weaver/WeaverLabelTest.java
@@ -1,0 +1,296 @@
+package selogger.weaver;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import selogger.EventType;
+import selogger.logging.Logging;
+import selogger.logging.io.MemoryLogger;
+import selogger.testutil.WeaveClassLoader;
+
+
+/**
+ * This class tests the events recorded by the 
+ * default + local variable access configuration.
+ * (WeaverTestAll checks only the frequency of events) 
+ */
+public class WeaverLabelTest {
+
+	private Class<?> wovenClass;
+	@SuppressWarnings("unused")
+	private MemoryLogger memoryLogger;
+	private EventIterator it;
+	
+	@Before
+	public void setup() throws IOException {
+		WeaveConfig config = new WeaveConfig(WeaveConfig.KEY_RECORD_LABEL); 
+		WeaveClassLoader loader = new WeaveClassLoader(config);
+		wovenClass = loader.loadAndWeaveClass("selogger.testdata.SimpleTarget");
+	
+		memoryLogger = new MemoryLogger();
+		Logging.setLogger(memoryLogger);
+		it = new EventIterator(memoryLogger, loader.getWeaveLog());
+	}
+	
+	@After
+	public void tearDown() {
+		wovenClass = null;
+	}
+
+	private void testBaseEvents(EventIterator it, Object instance) {
+		// Labels in <clinit> 
+		Assert.assertTrue(it.next());
+		Assert.assertEquals(EventType.LABEL, it.getEventType());
+		Assert.assertEquals("<clinit>", it.getMethodName());
+
+		// Labels in <init>
+		// call Object.<init>
+		Assert.assertTrue(it.next());
+		Assert.assertEquals(EventType.LABEL, it.getEventType());
+		Assert.assertEquals("<init>", it.getMethodName());
+
+		// Initialize a field
+		Assert.assertTrue(it.next());
+		Assert.assertEquals(EventType.LABEL, it.getEventType());
+		Assert.assertEquals("<init>", it.getMethodName());
+
+		// Return to the caller
+		Assert.assertTrue(it.next());
+		Assert.assertEquals(EventType.LABEL, it.getEventType());
+		Assert.assertEquals("<init>", it.getMethodName());
+
+	}
+	
+	@Test
+	public void testCatchLabel() throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
+		// Event generation
+		Object o = wovenClass.getDeclaredConstructor().newInstance();
+		
+		// Check events
+		testBaseEvents(it, o);
+		
+		// Execute a method that causes an exception
+		Method method = wovenClass.getMethod("exception", new Class<?>[0]);
+		Throwable result = null;
+		try {
+			method.invoke(o);
+		} catch (InvocationTargetException e) {
+			result = e.getCause();
+		}
+		Assert.assertNotNull(result);
+		
+		Assert.assertTrue(it.next());
+		Assert.assertEquals(EventType.LABEL, it.getEventType());
+		Assert.assertEquals("exception", it.getMethodName());
+		int firstLine = it.getLine();
+
+		Assert.assertTrue(it.next());
+		Assert.assertEquals(EventType.LABEL, it.getEventType());
+		Assert.assertEquals("exception", it.getMethodName());
+		Assert.assertEquals(firstLine + 1, it.getLine());
+		int index = it.getInstructionIndex();
+
+		// The code executes 4 instructions: line numbre, ALOAD, ICONST_0, and BALOAD
+		Assert.assertTrue(it.next());
+		Assert.assertEquals(EventType.CATCH_LABEL, it.getEventType());
+		Assert.assertEquals(index+4, it.getIntValue());
+
+		// Final label in the catch block
+		Assert.assertTrue(it.next());
+		Assert.assertEquals(EventType.LABEL, it.getEventType());
+
+		Assert.assertFalse(it.next());
+	}
+
+	@Test
+	public void testNestedIfConditions() throws IOException, IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
+		/* boolean nestedConditions(int x, int y)
+		 * 0: (L00000)
+		 * 1: (line=185)
+		 * 2: ILOAD 1 (x)
+		 * 3: IFLE L00013
+		 * 4: ILOAD 2 (y)
+		 * 5: IFLE L00013
+		 * 6: ILOAD 1 (x)
+		 * 7: ILOAD 2 (y)
+		 * 8: IF_ICMPNE L00013
+		 */
+		// Event generation
+		Object o = wovenClass.getDeclaredConstructor().newInstance();
+		
+		// Check events
+		testBaseEvents(it, o);
+
+		// Execute a method
+		Method m = wovenClass.getMethod("nestedConditions", new Class<?>[]{int.class, int.class});
+
+		// x == y == 1 reaches instruction 9
+		Object ret = m.invoke(o, new Object[] {Integer.valueOf(1), Integer.valueOf(1)});
+		Assert.assertTrue(((Boolean)ret).booleanValue());
+		
+		Assert.assertTrue(it.next());
+		Assert.assertEquals(EventType.LABEL, it.getEventType());
+		Assert.assertEquals(0, it.getIntValue());
+
+		Assert.assertTrue(it.next());
+		Assert.assertEquals(EventType.LABEL, it.getEventType());
+		Assert.assertEquals(8, it.getIntValue());
+		Assert.assertEquals(9, it.getInstructionIndex());
+		
+		Assert.assertFalse(it.next());
+	}
+	
+	@Test
+	public void testSecondIfCondition() throws IOException, IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
+		Object o = wovenClass.getDeclaredConstructor().newInstance();
+		
+		// Check events
+		testBaseEvents(it, o);
+
+		// Execute a method
+		Method m = wovenClass.getMethod("nestedConditions", new Class<?>[]{int.class, int.class});
+
+		Object ret = m.invoke(o, new Object[] {Integer.valueOf(1), Integer.valueOf(0)});
+		Assert.assertFalse(((Boolean)ret).booleanValue());
+		
+		// x == 1, y == 0 go to Instruction 13 from the second IF instruction (instruction 5)
+		Assert.assertTrue(it.next());
+		Assert.assertEquals(EventType.LABEL, it.getEventType());
+		Assert.assertEquals(0, it.getIntValue());
+
+		Assert.assertTrue(it.next());
+		Assert.assertEquals(EventType.LABEL, it.getEventType());
+		Assert.assertEquals(5, it.getIntValue());
+		Assert.assertEquals(13, it.getInstructionIndex());
+		
+		Assert.assertFalse(it.next());
+	}
+	
+	@Test
+	public void testFirstIfCondition() throws IOException, IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
+		Object o = wovenClass.getDeclaredConstructor().newInstance();
+		
+		// Check events
+		testBaseEvents(it, o);
+
+		// Execute a method
+		Method m = wovenClass.getMethod("nestedConditions", new Class<?>[]{int.class, int.class});
+
+		// x == y == 0 goes to Instruction 13 from the first IF instruction (instruction 3)
+		Object ret = m.invoke(o, new Object[] {Integer.valueOf(0), Integer.valueOf(0)});
+		Assert.assertFalse(((Boolean)ret).booleanValue());
+		
+		Assert.assertTrue(it.next());
+		Assert.assertEquals(EventType.LABEL, it.getEventType());
+		Assert.assertEquals(0, it.getIntValue());
+
+		Assert.assertTrue(it.next());
+		Assert.assertEquals(EventType.LABEL, it.getEventType());
+		Assert.assertEquals(3, it.getIntValue());
+		Assert.assertEquals(13, it.getInstructionIndex());
+		
+		Assert.assertFalse(it.next());
+	}
+	
+	/**
+	 * This method skips non-label events.
+	 */
+	private void skipNonLabelEvents() {
+		while (it.next()) {
+			if (it.getEventType() == EventType.LABEL || 
+				it.getEventType() == EventType.CATCH_LABEL) {
+				return;
+			}
+		}
+	}
+	
+	/**
+	 * This method confirms that "ALL" records the same LABEL events as "LABEL" configuration.
+	 */
+	@Test
+	public void testLabelUnchanged()  throws IOException, IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
+		WeaveConfig config = new WeaveConfig(WeaveConfig.KEY_RECORD_ALL); 
+		WeaveClassLoader loader = new WeaveClassLoader(config);
+		Class<?> allWovenClass = loader.loadAndWeaveClass("selogger.testdata.SimpleTarget");
+	
+		try {
+			memoryLogger = new MemoryLogger();
+			Logging.setLogger(memoryLogger);
+			it = new EventIterator(memoryLogger, loader.getWeaveLog());
+
+			Object o = allWovenClass.getDeclaredConstructor().newInstance();
+			Method m = allWovenClass.getMethod("nestedConditions", new Class<?>[]{int.class, int.class});
+
+			// x == y == 1 reaches instruction 9
+			Object ret = m.invoke(o, new Object[] {Integer.valueOf(1), Integer.valueOf(1)});
+			Assert.assertTrue(((Boolean)ret).booleanValue());
+
+			// calls the exception method
+			Method method = allWovenClass.getMethod("exception", new Class<?>[0]);
+			Throwable result = null;
+			try {
+				method.invoke(o);
+			} catch (InvocationTargetException e) {
+				result = e.getCause();
+			}
+			Assert.assertNotNull(result);
+
+			skipNonLabelEvents();
+			Assert.assertEquals(EventType.LABEL, it.getEventType());
+			Assert.assertEquals("<clinit>", it.getMethodName());
+
+			skipNonLabelEvents();
+			Assert.assertEquals(EventType.LABEL, it.getEventType());
+			Assert.assertEquals("<init>", it.getMethodName());
+
+			skipNonLabelEvents();
+			Assert.assertEquals(EventType.LABEL, it.getEventType());
+			Assert.assertEquals("<init>", it.getMethodName());
+
+			skipNonLabelEvents();
+			Assert.assertEquals(EventType.LABEL, it.getEventType());
+			Assert.assertEquals("<init>", it.getMethodName());
+
+			skipNonLabelEvents();
+			Assert.assertEquals(EventType.LABEL, it.getEventType());
+			Assert.assertEquals("nestedConditions", it.getMethodName());
+			Assert.assertEquals(0, it.getIntValue());
+
+			skipNonLabelEvents();
+			Assert.assertEquals(EventType.LABEL, it.getEventType());
+			Assert.assertEquals("nestedConditions", it.getMethodName());
+			Assert.assertEquals(8, it.getIntValue());
+			Assert.assertEquals(9, it.getInstructionIndex());
+
+			skipNonLabelEvents();
+			Assert.assertEquals(EventType.LABEL, it.getEventType());
+			Assert.assertEquals("exception", it.getMethodName());
+			int firstLine = it.getLine();
+
+			skipNonLabelEvents();
+			Assert.assertEquals(EventType.LABEL, it.getEventType());
+			Assert.assertEquals("exception", it.getMethodName());
+			Assert.assertEquals(firstLine + 1, it.getLine());
+			int index = it.getInstructionIndex();
+
+			skipNonLabelEvents();
+			Assert.assertEquals(EventType.CATCH_LABEL, it.getEventType());
+			Assert.assertEquals(index+4, it.getIntValue());
+
+			skipNonLabelEvents();
+			Assert.assertEquals(EventType.LABEL, it.getEventType());
+
+			skipNonLabelEvents();
+			Assert.assertFalse(it.next());
+
+		} finally {
+			allWovenClass  = null;
+		}
+	}
+}

--- a/tests/selogger/weaver/WeaverLabelTest.java
+++ b/tests/selogger/weaver/WeaverLabelTest.java
@@ -209,11 +209,9 @@ public class WeaverLabelTest {
 		Method m = wovenClass.getMethod("divide", new Class<?>[]{int.class});
 
 		// x == y == 0 goes to Instruction 13 from the first IF instruction (instruction 3)
-		try {
-			Object ret = m.invoke(o, new Object[] {Integer.valueOf(0)});
-		} catch (ArithmeticException e) {
-			
-		}
+		Object ret = m.invoke(o, new Object[] {Integer.valueOf(0)});
+		Assert.assertEquals(0, ((Integer)ret).intValue());
+		
 		Assert.assertTrue(it.next());
 		Assert.assertEquals(EventType.LABEL, it.getEventType());
 		Assert.assertEquals(0, it.getIntValue());

--- a/tests/selogger/weaver/WeaverLabelTest.java
+++ b/tests/selogger/weaver/WeaverLabelTest.java
@@ -3,6 +3,8 @@ package selogger.weaver;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -228,18 +230,6 @@ public class WeaverLabelTest {
 
 	
 	/**
-	 * This method skips non-label events.
-	 */
-	private void skipNonLabelEvents() {
-		while (it.next()) {
-			if (it.getEventType() == EventType.LABEL || 
-				it.getEventType() == EventType.CATCH_LABEL) {
-				return;
-			}
-		}
-	}
-	
-	/**
 	 * This method confirms that "ALL" records the same LABEL events as "LABEL" configuration.
 	 */
 	@Test
@@ -270,53 +260,53 @@ public class WeaverLabelTest {
 			}
 			Assert.assertNotNull(result);
 
-			skipNonLabelEvents();
+			List<EventType> labels = Arrays.asList(EventType.LABEL, EventType.CATCH_LABEL);
+			Assert.assertTrue(it.nextSpecifiedEvent(labels));
 			Assert.assertEquals(EventType.LABEL, it.getEventType());
 			Assert.assertEquals("<clinit>", it.getMethodName());
 
-			skipNonLabelEvents();
+			Assert.assertTrue(it.nextSpecifiedEvent(labels));
 			Assert.assertEquals(EventType.LABEL, it.getEventType());
 			Assert.assertEquals("<init>", it.getMethodName());
 
-			skipNonLabelEvents();
+			Assert.assertTrue(it.nextSpecifiedEvent(labels));
 			Assert.assertEquals(EventType.LABEL, it.getEventType());
 			Assert.assertEquals("<init>", it.getMethodName());
 
-			skipNonLabelEvents();
+			Assert.assertTrue(it.nextSpecifiedEvent(labels));
 			Assert.assertEquals(EventType.LABEL, it.getEventType());
 			Assert.assertEquals("<init>", it.getMethodName());
 
-			skipNonLabelEvents();
+			Assert.assertTrue(it.nextSpecifiedEvent(labels));
 			Assert.assertEquals(EventType.LABEL, it.getEventType());
 			Assert.assertEquals("nestedConditions", it.getMethodName());
 			Assert.assertEquals(0, it.getIntValue());
 
-			skipNonLabelEvents();
+			Assert.assertTrue(it.nextSpecifiedEvent(labels));
 			Assert.assertEquals(EventType.LABEL, it.getEventType());
 			Assert.assertEquals("nestedConditions", it.getMethodName());
 			Assert.assertEquals(8, it.getIntValue());
 			Assert.assertEquals(9, it.getInstructionIndex());
 
-			skipNonLabelEvents();
+			Assert.assertTrue(it.nextSpecifiedEvent(labels));
 			Assert.assertEquals(EventType.LABEL, it.getEventType());
 			Assert.assertEquals("exception", it.getMethodName());
 			int firstLine = it.getLine();
 
-			skipNonLabelEvents();
+			Assert.assertTrue(it.nextSpecifiedEvent(labels));
 			Assert.assertEquals(EventType.LABEL, it.getEventType());
 			Assert.assertEquals("exception", it.getMethodName());
 			Assert.assertEquals(firstLine + 1, it.getLine());
 			int index = it.getInstructionIndex();
 
-			skipNonLabelEvents();
+			Assert.assertTrue(it.nextSpecifiedEvent(labels));
 			Assert.assertEquals(EventType.CATCH_LABEL, it.getEventType());
 			Assert.assertEquals(index+4, it.getIntValue());
 
-			skipNonLabelEvents();
+			Assert.assertTrue(it.nextSpecifiedEvent(labels));
 			Assert.assertEquals(EventType.LABEL, it.getEventType());
 
-			skipNonLabelEvents();
-			Assert.assertFalse(it.next());
+			Assert.assertFalse(it.nextSpecifiedEvent(labels));
 
 		} finally {
 			allWovenClass  = null;

--- a/tests/selogger/weaver/WeaverLabelTest.java
+++ b/tests/selogger/weaver/WeaverLabelTest.java
@@ -197,6 +197,38 @@ public class WeaverLabelTest {
 		
 		Assert.assertFalse(it.next());
 	}
+
+	@Test
+	public void testDivideByZero() throws IOException, IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
+		Object o = wovenClass.getDeclaredConstructor().newInstance();
+		
+		// Check events
+		testBaseEvents(it, o);
+
+		// Execute a method
+		Method m = wovenClass.getMethod("divide", new Class<?>[]{int.class});
+
+		// x == y == 0 goes to Instruction 13 from the first IF instruction (instruction 3)
+		try {
+			Object ret = m.invoke(o, new Object[] {Integer.valueOf(0)});
+		} catch (ArithmeticException e) {
+			
+		}
+		Assert.assertTrue(it.next());
+		Assert.assertEquals(EventType.LABEL, it.getEventType());
+		Assert.assertEquals(0, it.getIntValue());
+
+		// The instruction causes ArithmeticException: LABEL, LDC 1, ILOAD, IDIV
+		Assert.assertTrue(it.next());
+		Assert.assertEquals(EventType.CATCH_LABEL, it.getEventType());
+		Assert.assertEquals(4, it.getIntValue());
+		
+		Assert.assertTrue(it.next());
+		Assert.assertEquals(EventType.LABEL, it.getEventType());
+
+		Assert.assertFalse(it.next());
+	}
+
 	
 	/**
 	 * This method skips non-label events.

--- a/tests/selogger/weaver/WeaverLabelTest.java
+++ b/tests/selogger/weaver/WeaverLabelTest.java
@@ -23,7 +23,6 @@ import selogger.testutil.WeaveClassLoader;
 public class WeaverLabelTest {
 
 	private Class<?> wovenClass;
-	@SuppressWarnings("unused")
 	private MemoryLogger memoryLogger;
 	private EventIterator it;
 	

--- a/tests/selogger/weaver/WeaverLocalTest.java
+++ b/tests/selogger/weaver/WeaverLocalTest.java
@@ -28,8 +28,6 @@ import selogger.weaver.method.MethodTransformer;
 public class WeaverLocalTest {
 
 	private Class<?> wovenClass;
-	@SuppressWarnings("unused")
-	private Class<?> innerClass;
 	private MemoryLogger memoryLogger;
 	private EventIterator it;
 	
@@ -38,7 +36,6 @@ public class WeaverLocalTest {
 		WeaveConfig config = new WeaveConfig(WeaveConfig.KEY_RECORD_DEFAULT_PLUS_LOCAL); 
 		WeaveClassLoader loader = new WeaveClassLoader(config);
 		wovenClass = loader.loadAndWeaveClass("selogger.testdata.SimpleTarget");
-		innerClass = loader.loadClassFromResource("selogger.testdata.SimpleTarget$StringComparator", "selogger/testdata/SimpleTarget$StringComparator.class");
 	
 		memoryLogger = new MemoryLogger();
 		Logging.setLogger(memoryLogger);
@@ -48,7 +45,6 @@ public class WeaverLocalTest {
 	@After
 	public void tearDown() {
 		wovenClass = null;
-		innerClass = null;
 	}
 
 	

--- a/tests/selogger/weaver/WeaverLocalTest.java
+++ b/tests/selogger/weaver/WeaverLocalTest.java
@@ -28,7 +28,6 @@ import selogger.weaver.method.MethodTransformer;
 public class WeaverLocalTest {
 
 	private Class<?> wovenClass;
-	private WeaveLog weaveLog;
 	@SuppressWarnings("unused")
 	private Class<?> innerClass;
 	private MemoryLogger memoryLogger;
@@ -39,7 +38,6 @@ public class WeaverLocalTest {
 		WeaveConfig config = new WeaveConfig(WeaveConfig.KEY_RECORD_DEFAULT_PLUS_LOCAL); 
 		WeaveClassLoader loader = new WeaveClassLoader(config);
 		wovenClass = loader.loadAndWeaveClass("selogger.testdata.SimpleTarget");
-		weaveLog = loader.getWeaveLog();
 		innerClass = loader.loadClassFromResource("selogger.testdata.SimpleTarget$StringComparator", "selogger/testdata/SimpleTarget$StringComparator.class");
 	
 		memoryLogger = new MemoryLogger();
@@ -1058,7 +1056,6 @@ public class WeaverLocalTest {
 		Assert.assertTrue(it.next());
 		Assert.assertEquals(EventType.CALL, it.getEventType());
 		Assert.assertSame(o, it.getObjectValue());
-		int callDataId = it.getDataId(); 
 
 		Assert.assertTrue(it.next());
 		Assert.assertEquals(EventType.METHOD_ENTRY, it.getEventType());

--- a/tests/selogger/weaver/WeaverLocalTest.java
+++ b/tests/selogger/weaver/WeaverLocalTest.java
@@ -378,16 +378,10 @@ public class WeaverLocalTest {
 		Assert.assertTrue(it.next());
 		Assert.assertEquals(EventType.ARRAY_LOAD, it.getEventType());
 		Assert.assertSame(array, it.getObjectValue());
-		int arrayLoad = it.getDataId();
-		int arrayLoadLocation = weaveLog.getDataEntries().get(arrayLoad).getInstructionIndex();
 
 		Assert.assertTrue(it.next());
 		Assert.assertEquals(EventType.ARRAY_LOAD_INDEX, it.getEventType());
 		Assert.assertEquals(0, it.getIntValue());
-
-		Assert.assertTrue(it.next());
-		Assert.assertEquals(EventType.CATCH_LABEL, it.getEventType());
-		Assert.assertEquals(arrayLoadLocation, it.getIntValue());
 
 		Assert.assertTrue(it.next());
 		Assert.assertEquals(EventType.CATCH, it.getEventType());
@@ -402,14 +396,8 @@ public class WeaverLocalTest {
 		Assert.assertSame(result, it.getObjectValue());
 
 		Assert.assertTrue(it.next());
-		int throwDataId = it.getDataId();
-		int throwDataIdLocation = weaveLog.getDataEntries().get(throwDataId).getInstructionIndex();
 		Assert.assertEquals(EventType.METHOD_THROW, it.getEventType());
 		Assert.assertSame(result, it.getObjectValue());
-
-		Assert.assertTrue(it.next());
-		Assert.assertEquals(EventType.CATCH_LABEL, it.getEventType());
-		Assert.assertEquals(throwDataIdLocation, it.getIntValue());
 
 		Assert.assertTrue(it.next());
 		Assert.assertEquals(EventType.CATCH, it.getEventType());
@@ -1105,9 +1093,6 @@ public class WeaverLocalTest {
 		Assert.assertEquals(0, it.getIntValue());
 
 		Assert.assertTrue(it.next());
-		Assert.assertEquals(EventType.CATCH_LABEL, it.getEventType());
-
-		Assert.assertTrue(it.next());
 		Assert.assertEquals(EventType.CATCH, it.getEventType());
 		Assert.assertSame(result, it.getObjectValue());
 
@@ -1124,9 +1109,6 @@ public class WeaverLocalTest {
 		Assert.assertSame(result, it.getObjectValue());
 
 		Assert.assertTrue(it.next());
-		Assert.assertEquals(EventType.CATCH_LABEL, it.getEventType());
-
-		Assert.assertTrue(it.next());
 		Assert.assertEquals(EventType.CATCH, it.getEventType());
 		Assert.assertSame(result, it.getObjectValue());
 		
@@ -1134,11 +1116,6 @@ public class WeaverLocalTest {
 		Assert.assertEquals(EventType.METHOD_EXCEPTIONAL_EXIT, it.getEventType());
 		Assert.assertSame(result, it.getObjectValue());
 		
-		Assert.assertTrue(it.next());
-		Assert.assertEquals(EventType.CATCH_LABEL, it.getEventType());
-		int callLocation = weaveLog.getDataEntries().get(callDataId).getInstructionIndex();
-		Assert.assertEquals(callLocation, it.getIntValue());
-
 		Assert.assertTrue(it.next());
 		Assert.assertEquals(EventType.CATCH, it.getEventType());
 		Assert.assertSame(result, it.getObjectValue());

--- a/tests/selogger/weaver/WeaverTest.java
+++ b/tests/selogger/weaver/WeaverTest.java
@@ -304,19 +304,12 @@ public class WeaverTest {
 		Assert.assertEquals(0, it.getIntValue());
 
 		Assert.assertTrue(it.next());
-		Assert.assertEquals(EventType.CATCH_LABEL, it.getEventType());
-
-		Assert.assertTrue(it.next());
 		Assert.assertEquals(EventType.CATCH, it.getEventType());
 		Assert.assertSame(result, it.getObjectValue());
 
 		Assert.assertTrue(it.next());
 		Assert.assertEquals(EventType.METHOD_THROW, it.getEventType());
 		Assert.assertSame(result, it.getObjectValue());
-
-		Assert.assertTrue(it.next());
-		Assert.assertEquals(EventType.CATCH_LABEL, it.getEventType());
-		// TODO it.getIntValue() should record the location of THROW instruction
 
 		Assert.assertTrue(it.next());
 		Assert.assertEquals(EventType.CATCH, it.getEventType());
@@ -1046,7 +1039,6 @@ public class WeaverTest {
 		Assert.assertTrue(it.next());
 		Assert.assertEquals(EventType.CALL, it.getEventType());
 		Assert.assertSame(o, it.getObjectValue());
-		int callDataId = it.getDataId();
 
 		Assert.assertTrue(it.next());
 		Assert.assertEquals(EventType.METHOD_ENTRY, it.getEventType());
@@ -1073,18 +1065,12 @@ public class WeaverTest {
 		Assert.assertEquals(0, it.getIntValue());
 
 		Assert.assertTrue(it.next());
-		Assert.assertEquals(EventType.CATCH_LABEL, it.getEventType());
-
-		Assert.assertTrue(it.next());
 		Assert.assertEquals(EventType.CATCH, it.getEventType());
 		Assert.assertSame(result, it.getObjectValue());
 
 		Assert.assertTrue(it.next());
 		Assert.assertEquals(EventType.METHOD_THROW, it.getEventType());
 		Assert.assertSame(result, it.getObjectValue());
-
-		Assert.assertTrue(it.next());
-		Assert.assertEquals(EventType.CATCH_LABEL, it.getEventType());
 
 		Assert.assertTrue(it.next());
 		Assert.assertEquals(EventType.CATCH, it.getEventType());
@@ -1094,9 +1080,6 @@ public class WeaverTest {
 		Assert.assertEquals(EventType.METHOD_EXCEPTIONAL_EXIT, it.getEventType());
 		Assert.assertSame(result, it.getObjectValue());
 		
-		Assert.assertTrue(it.next());
-		Assert.assertEquals(EventType.CATCH_LABEL, it.getEventType());
-
 		Assert.assertTrue(it.next());
 		Assert.assertEquals(EventType.CATCH, it.getEventType());
 		Assert.assertEquals(result, it.getObjectValue());


### PR DESCRIPTION
- Updated DataFormat.md
  - The trace file records instruction index because instructions may have no dataIDs
- Improved the implementation so that SELogger can record the same LABEL and CATCH_LABEL events irrelevant to weaving configurations
